### PR TITLE
fix: auto-resolve account_id when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Uses codemode to avoid dumping too much context to your agent.
 
 ### Create API Token
 
-Create a [Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) with the permissions you need.
+Create a [Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) with the permissions you need. If the token only has access to one account, the execute tool will auto-resolve `account_id`; tokens with multiple accounts still need `account_id` passed explicitly.
 
 Both **user tokens** and **account tokens** are supported:
 


### PR DESCRIPTION
⚠️ Heads up @mattzcarey this PR is intended to be more of a conversation starter... NOT a known working good piece of code that I think you should merge. :)

---

This PR adds automatic `account_id` resolution in the `execute` tool by calling `GET /accounts` when the caller omits `account_id` and the token has exactly one account. It keeps explicit `account_id` required when multiple accounts exist by returning a clear error that summarizes the available account IDs and names, and it errors early if the API base is unavailable.
Related issue: https://github.com/mattzcarey/cloudflare-mcp/issues/3