### PR TITLE
Fix GraphQL support

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -82,6 +82,16 @@ export default class CodeExecutor extends WorkerEntrypoint {
 
         const data = await response.json();
 
+        // Handle GraphQL responses (different format than REST)
+        if (path === '/graphql' || path.endsWith('/graphql')) {
+          if (data.errors && data.errors.length > 0) {
+            const msgs = data.errors.map(e => e.message).join(", ");
+            throw new Error("GraphQL error: " + msgs);
+          }
+          return { success: true, result: data.data, errors: [], messages: [] };
+        }
+
+        // Handle REST API responses
         if (!data.success) {
           const errors = data.errors.map(e => e.code + ": " + e.message).join(", ");
           throw new Error("Cloudflare API error: " + errors);


### PR DESCRIPTION
## Summary
- Fix GraphQL queries failing with `TypeError: Cannot read properties of null (reading 'map')`
- GraphQL responses use `{ data, errors }` format instead of REST's `{ success, result, errors, messages }`
- Added path-based detection for `/graphql` endpoints to normalize responses

Fixes #7

## Test plan
- [x] Verified GraphQL query `{ __typename }` returns normalized response
- [x] Verified GraphQL errors are properly caught and thrown
- [x] Verified REST API calls still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)